### PR TITLE
BCNY CI Support

### DIFF
--- a/.github/workflows/bcny-ci.yml
+++ b/.github/workflows/bcny-ci.yml
@@ -36,6 +36,8 @@ jobs:
           git config --global user.name "Arc Builder"
           git fetch origin pull/92/head
           git cherry-pick FETCH_HEAD
+          git fetch origin pull/93/head
+          git cherry-pick FETCH_HEAD
         working-directory: external/crashpad
 
       - name: Configure Sentry

--- a/.github/workflows/bcny-ci.yml
+++ b/.github/workflows/bcny-ci.yml
@@ -30,6 +30,10 @@ jobs:
           host_arch: amd64
           arch: ${{ matrix.arch }}
 
+      - name: Workaround for ARM64
+        if: ${{ matrix.arch }} == 'arm64'
+        run: git submodule update --remote external/crashpad/third_party/zlib
+
       - name: Configure Sentry
         run: >
           cmake -B out `

--- a/.github/workflows/bcny-ci.yml
+++ b/.github/workflows/bcny-ci.yml
@@ -15,9 +15,9 @@ jobs:
 
       matrix:
         include:
-          - arch: 'amd64'
+          - arch: 'AMD64'
             platform: 'x64'
-          - arch: 'arm64'
+          - arch: 'ARM64'
             platform: 'ARM64'
 
     steps:

--- a/.github/workflows/bcny-ci.yml
+++ b/.github/workflows/bcny-ci.yml
@@ -22,6 +22,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: "recursive"
 
       - uses: compnerd/gha-setup-vsdevenv@main
         with:

--- a/.github/workflows/bcny-ci.yml
+++ b/.github/workflows/bcny-ci.yml
@@ -40,3 +40,17 @@ jobs:
                 -D CMAKE_SYSTEM_PROCESSOR=${{ matrix.arch }} `
       - name: Build Sentry
         run: cmake --build out --config Release
+
+      - name: Stage Sentry
+        run: |
+          New-Item -ItemType Directory -Path sentry-native\bin\win64 -Force | Out-Null
+          New-Item -ItemType Directory -Path sentry-native\include -Force | Out-Null
+          New-Item -ItemType Directory -Path sentry-native\lib\win64 -Force | Out-Null
+          Copy-Item include\sentry.h sentry-native\include\
+          Copy-Item out\Release\sentry.dll sentry-native\bin\win64\
+          Copy-Item out\Release\sentry.lib sentry-native\lib\win64\
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: sentry-native-windows-${{ matrix.arch }}
+          path: sentry-native

--- a/.github/workflows/bcny-ci.yml
+++ b/.github/workflows/bcny-ci.yml
@@ -30,9 +30,10 @@ jobs:
           host_arch: amd64
           arch: ${{ matrix.arch }}
 
-      - name: Workaround for ARM64
-        if: matrix.arch == 'arm64'
-        run: git submodule update --remote third_party/zlib
+      - name: Build Workaround
+        run: |
+          git fetch pull/92/head
+          git cherry-pick FETCH_HEAD
         working-directory: external/crashpad
 
       - name: Configure Sentry

--- a/.github/workflows/bcny-ci.yml
+++ b/.github/workflows/bcny-ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: BCNY CI
 
 on:
   workflow_dispatch:

--- a/.github/workflows/bcny-ci.yml
+++ b/.github/workflows/bcny-ci.yml
@@ -47,9 +47,9 @@ jobs:
                 -G "Visual Studio 17 2022" `
                 -A ${{ matrix.platform }} `
                 -D CMAKE_SYSTEM_NAME=Windows `
-                -D CMAKE_SYSTEM_PROCESSOR=${{ matrix.arch }} `
+                -D CMAKE_SYSTEM_PROCESSOR=${{ matrix.arch }}
       - name: Build Sentry
-        run: cmake --build out --config Release
+        run: cmake --build out --config RelWithDebInfo
 
       - name: Stage Sentry
         run: |
@@ -57,8 +57,12 @@ jobs:
           New-Item -ItemType Directory -Path sentry-native\include -Force | Out-Null
           New-Item -ItemType Directory -Path sentry-native\lib\win64 -Force | Out-Null
           Copy-Item include\sentry.h sentry-native\include\
-          Copy-Item out\Release\sentry.dll sentry-native\bin\win64\
-          Copy-Item out\Release\sentry.lib sentry-native\lib\win64\
+          Copy-Item out\RelWithDebInfo\sentry.dll sentry-native\bin\win64\
+          Copy-Item out\RelWithDebInfo\sentry.pdb sentry-native\bin\win64\
+          Copy-Item out\crashpad_build\handler\RelWithDebInfo\crashpad_wer.dll sentry-native\bin\win64\
+          Copy-Item out\crashpad_build\handler\RelWithDebInfo\crashpad_wer.pdb sentry-native\bin\win64\
+          Copy-Item out\crashpad_build\handler\RelWithDebInfo\crashpad_handler.exe sentry-native\bin\win64\
+          Copy-Item out\RelWithDebInfo\sentry.lib sentry-native\lib\win64\
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/bcny-ci.yml
+++ b/.github/workflows/bcny-ci.yml
@@ -32,6 +32,8 @@ jobs:
 
       - name: Build Workaround
         run: |
+          git config --global user.email "builder@thebrowser.company"
+          git config --global user.name "Arc Builder"
           git fetch origin pull/92/head
           git cherry-pick FETCH_HEAD
         working-directory: external/crashpad

--- a/.github/workflows/bcny-ci.yml
+++ b/.github/workflows/bcny-ci.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Build Workaround
         run: |
-          git fetch pull/92/head
+          git fetch origin pull/92/head
           git cherry-pick FETCH_HEAD
         working-directory: external/crashpad
 

--- a/.github/workflows/bcny-ci.yml
+++ b/.github/workflows/bcny-ci.yml
@@ -32,11 +32,11 @@ jobs:
 
       - name: Configure Sentry
         run: >
-          cmake -B out
-                -D CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION=10.0.19041.0
-                -G "Visual Studio 17 2022"
-                -A ${{ matrix.platform }}
-                -D CMAKE_SYSTEM_NAME=Windows
-                -D CMAKE_SYSTEM_PROCESSOR=${{ matrix.arch }}
+          cmake -B out `
+                -D CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION=10.0.19041.0 `
+                -G "Visual Studio 17 2022" `
+                -A ${{ matrix.platform }} `
+                -D CMAKE_SYSTEM_NAME=Windows `
+                -D CMAKE_SYSTEM_PROCESSOR=${{ matrix.arch }} `
       - name: Build Sentry
         run: cmake --build out --config Release

--- a/.github/workflows/bcny-ci.yml
+++ b/.github/workflows/bcny-ci.yml
@@ -31,8 +31,9 @@ jobs:
           arch: ${{ matrix.arch }}
 
       - name: Workaround for ARM64
-        if: ${{ matrix.arch }} == 'arm64'
-        run: git submodule update --remote external/crashpad/third_party/zlib
+        if: matrix.arch == 'arm64'
+        run: git submodule update --remote third_party/zlib
+        working-directory: external/crashpad
 
       - name: Configure Sentry
         run: >


### PR DESCRIPTION
Enable CI for building binary releases of the Sentry SDK for Windows.