### PR TITLE
GHA: publish nuget packages to the GitHub Nuget Store

### DIFF
--- a/.github/workflows/bcny-ci.yml
+++ b/.github/workflows/bcny-ci.yml
@@ -101,7 +101,7 @@ jobs:
           NUGET_SOURCE_USERNAME: thebrowsercompany-bot2
           NUGET_SOURCE_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
           NUGET_API_KEY: ${{ secrets.GITHUB_TOKEN }}
-        run:
+        run: >
           if ((nuget sources List | Select-String "${env:NUGET_SOURCE_NAME}").Count -gt 0) {
             nuget sources Remove -Name "${env:NUGET_SOURCE_NAME}"
           }

--- a/.github/workflows/bcny-ci.yml
+++ b/.github/workflows/bcny-ci.yml
@@ -101,7 +101,7 @@ jobs:
           NUGET_SOURCE_USERNAME: thebrowsercompany-bot2
           NUGET_SOURCE_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
           NUGET_API_KEY: ${{ secrets.GITHUB_TOKEN }}
-        run: >
+        run: |
           if ((nuget sources List | Select-String "${env:NUGET_SOURCE_NAME}").Count -gt 0) {
             nuget sources Remove -Name "${env:NUGET_SOURCE_NAME}"
           }

--- a/.github/workflows/bcny-ci.yml
+++ b/.github/workflows/bcny-ci.yml
@@ -107,6 +107,6 @@ jobs:
           }
           nuget sources Add -Name ${env:NUGET_SOURCE_NAME} -Source ${env:NUGET_SOURCE_URL} -Username ${env:NUGET_SOURCE_USERNAME} -Password ${env:NUGET_SOURCE_PASSWORD} -StorePasswordInClearText
           nuget setApiKey ${env:NUGET_API_KEY} -Source ${env:NUGET_SOURCE_URL}
-          $pkgs = Get-ChildItem -Path io.sentry.win.crashpad.*.nupkg
+          $pkgs = Get-ChildItem -Path io.sentry.sentry-native.win.crashpad.*.nupkg
           nuget push $pkgs[0].Name -Source ${env:NUGET_SOURCE_URL} -SkipDuplicate
         shell: pwsh

--- a/.github/workflows/bcny-ci.yml
+++ b/.github/workflows/bcny-ci.yml
@@ -92,4 +92,20 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           name: windows-${{ matrix.arch }}.nupkg
-          path: io.sentry.sentry-native.win.*.0.0.0-*.nupkg
+          path: io.sentry.sentry-native.win.crashpad.*.nupkg
+
+      - name: Publish NuGet Packages
+        env:
+          NUGET_SOURCE_NAME: TheBrowserCompany
+          NUGET_SOURCE_URL: https://nuget.pkg.github.com/thebrowsercompany/index.json
+          NUGET_SOURCE_USERNAME: thebrowsercompany-bot2
+          NUGET_SOURCE_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+          NUGET_API_KEY: ${{ secrets.GITHUB_TOKEN }}
+        run:
+          if ((nuget sources List | Select-String "${env:NUGET_SOURCE_NAME}").Count -gt 0) {
+            nuget sources Remove -Name "${env:NUGET_SOURCE_NAME}"
+          }
+          nuget sources Add -Name ${env:NUGET_SOURCE_NAME} -Source ${env:NUGET_SOURCE_URL} -Username ${env:NUGET_SOURCE_USERNAME} -Password ${env:NUGET_SOURCE_PASSWORD} -StorePasswordInClearText
+          nuget setApiKey ${env:NUGET_API_KEY} -Source ${env:NUGET_SOURCE_URL}
+          nuget push io.sentry.win.crashpad.*.nupkg -Source ${env:NUGET_SOURCE_URL} -SkipDuplicate
+        shell: pwsh

--- a/.github/workflows/bcny-ci.yml
+++ b/.github/workflows/bcny-ci.yml
@@ -107,5 +107,6 @@ jobs:
           }
           nuget sources Add -Name ${env:NUGET_SOURCE_NAME} -Source ${env:NUGET_SOURCE_URL} -Username ${env:NUGET_SOURCE_USERNAME} -Password ${env:NUGET_SOURCE_PASSWORD} -StorePasswordInClearText
           nuget setApiKey ${env:NUGET_API_KEY} -Source ${env:NUGET_SOURCE_URL}
-          nuget push io.sentry.win.crashpad.*.nupkg -Source ${env:NUGET_SOURCE_URL} -SkipDuplicate
+          $pkgs = Get-ChildItem -Path io.sentry.win.crashpad.*.nupkg
+          nuget push @pkgs -Source ${env:NUGET_SOURCE_URL} -SkipDuplicate
         shell: pwsh

--- a/.github/workflows/bcny-ci.yml
+++ b/.github/workflows/bcny-ci.yml
@@ -108,5 +108,5 @@ jobs:
           nuget sources Add -Name ${env:NUGET_SOURCE_NAME} -Source ${env:NUGET_SOURCE_URL} -Username ${env:NUGET_SOURCE_USERNAME} -Password ${env:NUGET_SOURCE_PASSWORD} -StorePasswordInClearText
           nuget setApiKey ${env:NUGET_API_KEY} -Source ${env:NUGET_SOURCE_URL}
           $pkgs = Get-ChildItem -Path io.sentry.win.crashpad.*.nupkg
-          nuget push @pkgs -Source ${env:NUGET_SOURCE_URL} -SkipDuplicate
+          nuget push $pkgs[0].Name -Source ${env:NUGET_SOURCE_URL} -SkipDuplicate
         shell: pwsh


### PR DESCRIPTION
This pushes the new nuget packages to the nuget source to ease the distribution for our builds.