### PR TITLE
Upload the DLLs to the symbol server

### DIFF
--- a/.github/workflows/bcny-ci.yml
+++ b/.github/workflows/bcny-ci.yml
@@ -108,3 +108,11 @@ jobs:
           personalAccessToken: ${{ secrets.SYMBOL_SERVER_PAT }}
           symbolsFolder: ${{ github.workspace }}\sentry-native-development\usr\bin
           searchPattern: '**/*.pdb'
+
+      - name: Upload DLLs to Azure
+        uses: microsoft/action-publish-symbols@719c40b80e38bca806f3e01e1e3dd3a67554cd68
+        with:
+          accountName: thebrowsercompany
+          personalAccessToken: ${{ secrets.SYMBOL_SERVER_PAT }}
+          symbolsFolder: ${{ github.workspace }}\sentry-native-development\usr\bin
+          searchPattern: '**/*.dll'

--- a/.github/workflows/bcny-ci.yml
+++ b/.github/workflows/bcny-ci.yml
@@ -107,4 +107,4 @@ jobs:
           accountName: thebrowsercompany
           personalAccessToken: ${{ secrets.SYMBOL_SERVER_PAT }}
           symbolsFolder: ${{ github.workspace }}\sentry-native-development\usr\bin
-          searchPattern: '**/*.@(dll|exe|pdb)'
+          searchPattern: '**/*.{dll,exe,pdb}'

--- a/.github/workflows/bcny-ci.yml
+++ b/.github/workflows/bcny-ci.yml
@@ -107,4 +107,12 @@ jobs:
           accountName: thebrowsercompany
           personalAccessToken: ${{ secrets.SYMBOL_SERVER_PAT }}
           symbolsFolder: ${{ github.workspace }}\sentry-native-development\usr\bin
-          searchPattern: '**/*.{dll,exe,pdb}'
+          searchPattern: '**/*.pdb'
+
+      - name: Upload DLLs to Azure
+        uses: microsoft/action-publish-symbols@719c40b80e38bca806f3e01e1e3dd3a67554cd68
+        with:
+          accountName: thebrowsercompany
+          personalAccessToken: ${{ secrets.SYMBOL_SERVER_PAT }}
+          symbolsFolder: ${{ github.workspace }}\sentry-native-development\usr\bin
+          searchPattern: '**/*.dll'

--- a/.github/workflows/bcny-ci.yml
+++ b/.github/workflows/bcny-ci.yml
@@ -107,12 +107,4 @@ jobs:
           accountName: thebrowsercompany
           personalAccessToken: ${{ secrets.SYMBOL_SERVER_PAT }}
           symbolsFolder: ${{ github.workspace }}\sentry-native-development\usr\bin
-          searchPattern: '**/*.pdb'
-
-      - name: Upload DLLs to Azure
-        uses: microsoft/action-publish-symbols@719c40b80e38bca806f3e01e1e3dd3a67554cd68
-        with:
-          accountName: thebrowsercompany
-          personalAccessToken: ${{ secrets.SYMBOL_SERVER_PAT }}
-          symbolsFolder: ${{ github.workspace }}\sentry-native-development\usr\bin
-          searchPattern: '**/*.dll'
+          searchPattern: '**/*.@(dll|exe|pdb)'


### PR DESCRIPTION
This makes the DLLs available on the symbol server in addition to the PDBs (it's standard practice to upload both).