### PR TITLE
 Add plumbing for getting crashpad_handler's  IPC pipe name

### DIFF
--- a/include/sentry.h
+++ b/include/sentry.h
@@ -1217,7 +1217,7 @@ SENTRY_API void sentry_options_set_database_pathw_n(
  * Returns the name of the named pipe where the Crashpad handler is listening
  * for child connections if Crashpad is active backend.
  */
-SENTRY_API const wchar_t *sentry_options_get_handler_ipc_pathw(
+SENTRY_API const wchar_t *sentry_options_get_handler_ipc_pipew(
     sentry_options_t *opts);
 
 #endif

--- a/include/sentry.h
+++ b/include/sentry.h
@@ -1212,6 +1212,14 @@ SENTRY_API void sentry_options_set_database_pathw(
     sentry_options_t *opts, const wchar_t *path);
 SENTRY_API void sentry_options_set_database_pathw_n(
     sentry_options_t *opts, const wchar_t *path, size_t path_len);
+
+/**
+ * Returns the name of the named pipe where the Crashpad handler is listening
+ * for child connections if Crashpad is active backend.
+ */
+SENTRY_API const wchar_t *sentry_options_get_handler_ipc_pathw(
+    sentry_options_t *opts);
+
 #endif
 
 /**

--- a/src/backends/sentry_backend_crashpad.cpp
+++ b/src/backends/sentry_backend_crashpad.cpp
@@ -357,7 +357,7 @@ crashpad_backend_startup(
             /* asynchronous_start */ false, attachments);
 #ifdef SENTRY_PLATFORM_WINDOWS
         std::wstring pipe_name = data->client->GetHandlerIPCPipe();
-        const_cast<sentry_options_t *>(options)->handler_ipc_path
+        const_cast<sentry_options_t *>(options)->handler_ipc_pipe
             = sentry__path_new(pipe_name.c_str());
 #endif
         sentry_free(minidump_url);

--- a/src/backends/sentry_backend_crashpad.cpp
+++ b/src/backends/sentry_backend_crashpad.cpp
@@ -355,6 +355,11 @@ crashpad_backend_startup(
             annotations, arguments,
             /* restartable */ true,
             /* asynchronous_start */ false, attachments);
+#ifdef SENTRY_PLATFORM_WINDOWS
+        std::wstring pipe_name = data->client->GetHandlerIPCPipe();
+        const_cast<sentry_options_t *>(options)->handler_ipc_path
+            = sentry__path_new(pipe_name.c_str());
+#endif
         sentry_free(minidump_url);
     } else {
         SENTRY_WARN(

--- a/src/sentry_options.c
+++ b/src/sentry_options.c
@@ -538,9 +538,9 @@ sentry_options_set_database_pathw(sentry_options_t *opts, const wchar_t *path)
 #endif
 
 const wchar_t *
-sentry_options_get_handler_ipc_pathw(sentry_options_t *opts)
+sentry_options_get_handler_ipc_pipew(sentry_options_t *opts)
 {
-    return opts->handler_ipc_path ? opts->handler_ipc_path->path : NULL;
+    return opts->handler_ipc_pipe ? opts->handler_ipc_pipe->path : NULL;
 }
 
 /**

--- a/src/sentry_options.c
+++ b/src/sentry_options.c
@@ -537,6 +537,12 @@ sentry_options_set_database_pathw(sentry_options_t *opts, const wchar_t *path)
 }
 #endif
 
+const wchar_t *
+sentry_options_get_handler_ipc_pathw(sentry_options_t *opts)
+{
+    return opts->handler_ipc_path ? opts->handler_ipc_path->path : NULL;
+}
+
 /**
  * Sets the maximum number of spans that can be attached to a
  * transaction.

--- a/src/sentry_options.h
+++ b/src/sentry_options.h
@@ -68,6 +68,11 @@ typedef struct sentry_options_s {
     struct sentry_backend_s *backend;
     sentry_session_t *session;
 
+#ifdef SENTRY_PLATFORM_WINDOWS
+    /* Filled out after crashpad startup, only on Windows */
+    sentry_path_t* handler_ipc_path;
+#endif
+
     long user_consent;
     long refcount;
     uint64_t shutdown_timeout;

--- a/src/sentry_options.h
+++ b/src/sentry_options.h
@@ -70,7 +70,7 @@ typedef struct sentry_options_s {
 
 #ifdef SENTRY_PLATFORM_WINDOWS
     /* Filled out after crashpad startup, only on Windows */
-    sentry_path_t* handler_ipc_path;
+    sentry_path_t* handler_ipc_pipe;
 #endif
 
     long user_consent;


### PR DESCRIPTION
This will allow a child process to connect to the pipe server rather than starting its own crashpad_handler.